### PR TITLE
Hotfix/202110/nav background color

### DIFF
--- a/NavigationBarColorSample/SceneDelegate.swift
+++ b/NavigationBarColorSample/SceneDelegate.swift
@@ -23,23 +23,31 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // ナビゲージョンアイテムの文字色
         UINavigationBar.appearance().tintColor = UIColor.red
         
-        UINavigationBar.appearance().titleTextAttributes =
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor.green
+            appearance.titleTextAttributes =
             // ナビゲーションバーのタイトルの文字色
             [.foregroundColor: UIColor.blue,
              // フォントの種類
              .font: UIFont(name: "Times New Roman",
                            // フォントサイズ
                            size: 27)!]
-        
-        if #available(iOS 15.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = UIColor.green
             UINavigationBar.appearance().standardAppearance = appearance
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
+            
         } else {
             // ナビゲーションバーの背景色
             UINavigationBar.appearance().barTintColor = UIColor.green
+            
+            UINavigationBar.appearance().titleTextAttributes =
+            // ナビゲーションバーのタイトルの文字色
+            [.foregroundColor: UIColor.blue,
+             // フォントの種類
+             .font: UIFont(name: "Times New Roman",
+                           // フォントサイズ
+                           size: 27)!]
         }
     }
 

--- a/NavigationBarColorSample/SceneDelegate.swift
+++ b/NavigationBarColorSample/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // 個別に色を変えたい場合、そのViewControllerにコードを書くことで個別に色を変えられる
         // ナビゲージョンアイテムの文字色
         UINavigationBar.appearance().tintColor = UIColor.red
-
+        
         UINavigationBar.appearance().titleTextAttributes =
             // ナビゲーションバーのタイトルの文字色
             [.foregroundColor: UIColor.blue,
@@ -30,6 +30,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
              .font: UIFont(name: "Times New Roman",
                            // フォントサイズ
                            size: 27)!]
+        
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor.green
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        } else {
+            // ナビゲーションバーの背景色
+            UINavigationBar.appearance().barTintColor = UIColor.green
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
- iOS 15 NavigationBar の背景色を修正
  - iOS 15 へアップデートされたことにより背景色に不具合が生じたため
- iOS 15 NavigationBar のタイトルの文字色を修正
  - iOS 15 へアップデートされたことによりタイトルの文字色に不具合が生じたため